### PR TITLE
Integrate homebrew @ macos

### DIFF
--- a/llvmenv.zsh
+++ b/llvmenv.zsh
@@ -1,7 +1,11 @@
 #!/usr/bin/zsh
 
 function llvmenv_remove_path() {
-  path_base=${XDG_DATA_HOME:-$HOME/.local/share/llvmenv}
+  if [[ `uname` == "Darwin" ]]; then
+    path_base=${LLVMENV_HOME:-$HOME/Library/Application Support/llvmenv}
+  else
+    path_base=${XDG_DATA_HOME:-$HOME/.local/share/llvmenv}
+  fi
   path=("${(@)path:#$path_base/*}")
 }
 
@@ -14,7 +18,7 @@ function llvmenv_append_path() {
 }
 
 function llvmenv_env_llvm_sys () {
-  export LLVM_SYS_$(llvmenv version --major --minor)_PREFIX=$(llvmenv prefix)
+  export LLVM_SYS_$(llvmenv version --major --minor)_PREFIX="$(llvmenv prefix)"
 }
 
 function llvmenv_update () {

--- a/src/bin/llvmenv.rs
+++ b/src/bin/llvmenv.rs
@@ -17,7 +17,10 @@ use structopt::StructOpt;
 )]
 enum LLVMEnv {
     #[structopt(name = "init", about = "Initialize llvmenv")]
-    Init {},
+    Init {
+        #[structopt(short, long, help = "Force to reinitiailize llvmenv")]
+        force: bool,
+    },
 
     #[structopt(name = "builds", about = "List usable build")]
     Builds {},
@@ -113,7 +116,7 @@ fn main() -> error::Result<()> {
 
     let opt = LLVMEnv::from_args();
     match opt {
-        LLVMEnv::Init {} => config::init_config()?,
+        LLVMEnv::Init { force } => config::init_config(force)?,
 
         LLVMEnv::Builds {} => {
             let builds = build::builds()?;

--- a/src/bin/llvmenv.rs
+++ b/src/bin/llvmenv.rs
@@ -108,10 +108,12 @@ fn main() -> error::Result<()> {
         ConfigBuilder::new().set_time_to_local(true).build(),
         TerminalMode::Mixed,
     )
-    .or(SimpleLogger::init(
-        LevelFilter::Info,
-        ConfigBuilder::new().set_time_to_local(true).build(),
-    ))
+    .or_else(|_| {
+        SimpleLogger::init(
+            LevelFilter::Info,
+            ConfigBuilder::new().set_time_to_local(true).build(),
+        )
+    })
     .unwrap();
 
     let opt = LLVMEnv::from_args();

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,14 +38,81 @@ pub fn data_dir() -> Result<PathBuf> {
     Ok(path)
 }
 
+#[cfg(target_os = "macos")]
+pub fn homebrew_dir() -> Option<PathBuf> {
+    std::process::Command::new("brew")
+        .arg("--prefix")
+        .check_output()
+        .ok()
+        .map(|(stdout, _)| {
+            let path = PathBuf::from(stdout.trim()).join("opt");
+
+            info!("found homebrew @ {}", path.display());
+
+            path
+        })
+}
+
+#[cfg(target_os = "macos")]
+pub fn append_homebrew_llvm<P: AsRef<std::path::Path>>(dir: P, out: &mut dyn Write) -> Result<()> {
+    use semver::Version;
+    use std::os::unix::fs::symlink;
+    use std::process::Command;
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+
+        if file_name == "llvm" || file_name.starts_with("llvm@") {
+            let (stdout, _) = Command::new(path.join("bin/llvm-config"))
+                .arg("--version")
+                .check_output()?;
+            let version = Version::parse(&stdout).map_err(|_| Error::invalid_version(&stdout))?;
+            let name = format!("homebrew-llvm{}", version.major);
+
+            info!("found {} @ {}", name, path.display());
+
+            let target = data_dir()?.join(&name);
+            if !target.exists() {
+                symlink(&path, &target)?;
+            }
+
+            write!(
+                out,
+                r#"
+[{name}]
+name = "{name}"
+version = "{version}"
+path = "{path}"
+"#,
+                name = name,
+                version = version,
+                path = path.display(),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Initialize configure file
-pub fn init_config() -> Result<()> {
+pub fn init_config(force: bool) -> Result<()> {
     let dir = config_dir()?;
     let entry = dir.join(ENTRY_TOML);
-    if !entry.exists() {
+    if force || !entry.exists() {
         info!("Create default entry setting: {}", entry.display());
         let mut f = fs::File::create(&entry).with(&entry)?;
         f.write(LLVM_MIRROR.as_bytes()).with(&entry)?;
+        #[cfg(target_os = "macos")]
+        if let Some(dir) = homebrew_dir() {
+            append_homebrew_llvm(dir, &mut f)?;
+        }
         Ok(())
     } else {
         Err(Error::ConfigureAlreadyExists { path: entry })

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -309,7 +309,7 @@ pub fn load_entry(name: &str) -> Result<Entry> {
         }
 
         if let Some(version) = entry.version() {
-            if let Some(req) = VersionReq::parse(name).ok() {
+            if let Ok(req) = VersionReq::parse(name) {
                 if req.matches(version) {
                     return Ok(entry);
                 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -283,7 +283,7 @@ where
         }
         buf.copy_from_slice(&bytes);
         self.bar.inc(bytes.len() as u64);
-        return Ok(bytes.len());
+        Ok(bytes.len())
     }
 }
 


### PR DESCRIPTION
On MacOS, we typically use [homebrew](https://brew.sh/) to manage third-party dependencies.

This PR will first check to see if homebrew has LLVM installed, and append those entries to `entry.toml`.

```toml
[homebrew-llvm9]
name = "homebrew-llvm9"
version = "9.0.1"
path = "/usr/local/opt/llvm@9"

[homebrew-llvm11]
name = "homebrew-llvm11"
version = "11.0.0"
path = "/usr/local/opt/llvm"
```
Then creates a symbolic link to an existing installation directory.

After that, llvmenv will be able to use these pre-built packages directly.
```sh
$ llvmenv local homebrew-llvm9
$ llvm-config --cflags
-I/usr/local/Cellar/llvm@9/9.0.1_2/include  -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS

$ llvmenv local homebrew-llvm11
$ llvm-config --cflags
-I/usr/local/Cellar/llvm/11.0.0/include  -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
```