### PR TITLE
🔧 configurable paths for config, data and cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llvmenv"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>",
            "Alexander Ronald Altman <alexanderaltman@me.com>"]
 edition = "2018"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use log::info;
-use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
+use std::{env, fs};
 
 use crate::error::*;
 
@@ -11,19 +11,28 @@ pub const ENTRY_TOML: &str = "entry.toml";
 const LLVM_MIRROR: &str = include_str!("llvm-mirror.toml");
 
 pub fn config_dir() -> Result<PathBuf> {
-    let path = dirs::config_dir()
-        .ok_or(Error::UnsupportedOS)?
-        .join(APP_NAME);
+    let custom_llvmenv_config_dir = env::var("LLVMENV_CONFIG_DIR");
+    let path = match custom_llvmenv_config_dir {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => dirs::config_dir()
+            .ok_or(Error::UnsupportedOS)?
+            .join(APP_NAME),
+    };
     if !path.exists() {
         fs::create_dir_all(&path).with(&path)?;
     }
-    Ok(path)
+    return Ok(path);
 }
 
 pub fn cache_dir() -> Result<PathBuf> {
-    let path = dirs::cache_dir()
-        .ok_or(Error::UnsupportedOS)?
-        .join(APP_NAME);
+    let custom_llvmenv_cache_dir = env::var("LLVMENV_CACHE_DIR");
+
+    let path = match custom_llvmenv_cache_dir {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => dirs::cache_dir()
+            .ok_or(Error::UnsupportedOS)?
+            .join(APP_NAME),
+    };
     if !path.exists() {
         fs::create_dir_all(&path).with(&path)?;
     }
@@ -31,7 +40,11 @@ pub fn cache_dir() -> Result<PathBuf> {
 }
 
 pub fn data_dir() -> Result<PathBuf> {
-    let path = dirs::data_dir().ok_or(Error::UnsupportedOS)?.join(APP_NAME);
+    let custom_llvmenv_cache_dir = env::var("LLVMENV_DATA_DIR");
+    let path = match custom_llvmenv_cache_dir {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => dirs::data_dir().ok_or(Error::UnsupportedOS)?.join(APP_NAME),
+    };
     if !path.exists() {
         fs::create_dir_all(&path).with(&path)?;
     }


### PR DESCRIPTION
# Description

Let the possibility to override paths for `config_dir`, `cache_dir`, `data_dir`.
Currently the values are the ones returned from  `dirs` crate, specifically `dirs::config_dir`, `dirs::cache_dir`, `dirs::data_dir`. 
This PR enables to override those values with 3 optional environment variables:
- `LLVMENV_CONFIG_DIR`
- `LLVMENV_CACHE_DIR`
- `LLVMENV_DATA_DIR`